### PR TITLE
Env-specific IP ranges (ENT-API-G)

### DIFF
--- a/iac/environments/dev/main.tf
+++ b/iac/environments/dev/main.tf
@@ -3,6 +3,12 @@
 #
 # Deploy shared resources
 #########################################################
+locals {
+  env_allowed_ips = <<EOT
+allow 35.177.168.113/32; # Ent-APIG external (DEV)
+EOT  
+}
+
 module "deploy-all" {
   source           = "../../modules/configs/deploy-all"
   space            = "development"
@@ -10,4 +16,5 @@ module "deploy-all" {
   cf_username      = var.cf_username
   cf_password      = var.cf_password
   syslog_drain_url = "https://44f18302-59ca-4034-a82e-63f742e60a3e-ls.logit.io:12732"
+  env_allowed_ips  = local.env_allowed_ips
 }

--- a/iac/environments/int/main.tf
+++ b/iac/environments/int/main.tf
@@ -3,6 +3,12 @@
 #
 # Deploy shared resources
 #########################################################
+locals {
+  env_allowed_ips = <<EOT
+allow 3.9.61.85/32; # Ent-APIG external (TST/INT)
+EOT  
+}
+
 module "deploy-all" {
   source           = "../../modules/configs/deploy-all"
   space            = "int"
@@ -10,4 +16,5 @@ module "deploy-all" {
   cf_username      = var.cf_username
   cf_password      = var.cf_password
   syslog_drain_url = "https://d74f58fc-479f-413d-bb66-1cec772b5f5a-ls.logit.io:17256"
+  env_allowed_ips  = local.env_allowed_ips
 }

--- a/iac/environments/nft/main.tf
+++ b/iac/environments/nft/main.tf
@@ -3,6 +3,12 @@
 #
 # Deploy shared resources
 #########################################################
+locals {
+  env_allowed_ips = <<EOT
+allow 3.9.61.85/32; # Ent-APIG external (TST/INT)
+EOT  
+}
+
 module "deploy-all" {
   source           = "../../modules/configs/deploy-all"
   space            = "nft"
@@ -11,4 +17,5 @@ module "deploy-all" {
   cf_password      = var.cf_password
   # This is logit.io DEV stack - update to NFT after it is created (zendesk 28070)
   syslog_drain_url = "https://44f18302-59ca-4034-a82e-63f742e60a3e-ls.logit.io:12732"
+  env_allowed_ips  = local.env_allowed_ips  
 }

--- a/iac/modules/configs/deploy-all/main.tf
+++ b/iac/modules/configs/deploy-all/main.tf
@@ -29,5 +29,5 @@ module "ip-router" {
   organisation = var.organisation
   space        = var.space
   environment  = var.environment
-  allowed_ips  = var.allowed_ips
+  allowed_ips  = join("\n", [var.allowed_ips, var.env_allowed_ips])
 }

--- a/iac/modules/configs/deploy-all/variables.tf
+++ b/iac/modules/configs/deploy-all/variables.tf
@@ -35,3 +35,7 @@ allow 203.99.209.0/24;   # Cog External VPN
 allow 18.133.142.117/32; # Cog 'SCALE Test Machine 3' in NFT
 EOT
 }
+
+variable env_allowed_ips {
+  default = ""
+}


### PR DESCRIPTION
Applied OK on SBX2 (and I could see both sets of IPs via `cf env [app-name]` 👍 
Mapped TST to NFT for now - not sure if that's right but can always update.