### PR TITLE
Disable proxy (response) buffering in nginx

### DIFF
--- a/iac/modules/ip-router/app/nginx.conf
+++ b/iac/modules/ip-router/app/nginx.conf
@@ -97,6 +97,7 @@ http {
       proxy_set_header Connection "";
       proxy_set_header Host $cf_forwarded_host;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_buffering off;
 
       # Use XX-CF-APP-INSTANCE on the original request if you wish to target an instance
       proxy_set_header X-CF-APP-INSTANCE $http_xx_cf_app_instance;


### PR DESCRIPTION
Clutching at straws a bit here - but this is deployed to SBX2 and I've been hitting the create project and criteria endpoints with (to date) no recurrence of the EOF error in the webclient in the Tenders API.